### PR TITLE
fix - issue 68

### DIFF
--- a/src/main/java/com/jootcamp/superboard/comment/service/CommentService.java
+++ b/src/main/java/com/jootcamp/superboard/comment/service/CommentService.java
@@ -64,7 +64,7 @@ public class CommentService {
         CommentEntity comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new CommentNotFoundException(commentId));
 
-        hasPermission(userId, comment.getUserId());
+        checkPermission(userId, comment.getUserId());
 
         comment.setDeleted(false);
 
@@ -81,7 +81,7 @@ public class CommentService {
                 .orElseThrow(()->new CommentNotFoundException(commentId));
 
         // 3. 해당하는 사용자가 권한이 있는가?
-        hasPermission(upsertComment.getUserId(), comment.getUserId());
+        checkPermission(upsertComment.getUserId(), comment.getUserId());
 
         // 4. 수정
         comment.updateContent(upsertComment.getContent());
@@ -98,7 +98,7 @@ public class CommentService {
 
     }
 
-    private void hasPermission(long requestUserId, long commentUserId){
+    private void checkPermission(long requestUserId, long commentUserId){
         if(requestUserId!=commentUserId)
             throw new ForbiddenException("권한 없음");
     }

--- a/src/main/java/com/jootcamp/superboard/comment/service/CommentService.java
+++ b/src/main/java/com/jootcamp/superboard/comment/service/CommentService.java
@@ -7,7 +7,7 @@ import com.jootcamp.superboard.comment.service.dto.Comment;
 import com.jootcamp.superboard.comment.service.dto.CommentPage;
 import com.jootcamp.superboard.comment.service.dto.UpsertComment;
 import com.jootcamp.superboard.common.dto.PageMetadata;
-import com.jootcamp.superboard.common.exception.UnauthorizedException;
+import com.jootcamp.superboard.common.exception.ForbiddenException;
 import com.jootcamp.superboard.post.repository.PostRepository;
 import com.jootcamp.superboard.post.repository.entity.PostEntity;
 import com.jootcamp.superboard.post.repository.execption.PostNotFoundException;
@@ -64,7 +64,7 @@ public class CommentService {
         CommentEntity comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new CommentNotFoundException(commentId));
 
-        authorized(userId, comment);
+        hasPermission(userId, comment.getUserId());
 
         comment.setDeleted(false);
 
@@ -81,7 +81,7 @@ public class CommentService {
                 .orElseThrow(()->new CommentNotFoundException(commentId));
 
         // 3. 해당하는 사용자가 권한이 있는가?
-        authorized(upsertComment.getUserId(), comment);
+        hasPermission(upsertComment.getUserId(), comment.getUserId());
 
         // 4. 수정
         comment.updateContent(upsertComment.getContent());
@@ -98,9 +98,9 @@ public class CommentService {
 
     }
 
-    private void authorized(long userId, CommentEntity comment){
-        if(comment.getUserId()!=userId)
-            throw new UnauthorizedException("권한이 없습니다");
+    private void hasPermission(long requestUserId, long commentUserId){
+        if(requestUserId!=commentUserId)
+            throw new ForbiddenException("권한 없음");
     }
 
 }


### PR DESCRIPTION
`CommentService`의 `authorized()` 메소드 수정
- `hasPermission()`으로 메소드명 변경
- 매개변수를 comment -> user id 받도록 변경
- return을 UnauthorizedException() -> Forbidden으로 변경

close #68