### PR TITLE
fix - issue 92 : Post에 BoardId 필드 추가

### DIFF
--- a/src/main/java/com/jootcamp/superboard/post/controller/PostApiController.java
+++ b/src/main/java/com/jootcamp/superboard/post/controller/PostApiController.java
@@ -30,7 +30,7 @@ public class PostApiController {
     public ResponseEntity<IdResponse> createPost(@RequestBody UpsertPostRequest postRequest,
                                                  @PathVariable("boardId") long boardId,
                                                  @UserInfo AuthUser authUser) {
-        long postId = postService.create(postRequest.toUpsertPost(authUser.getUserId()));
+        long postId = postService.create(postRequest.toUpsertPost(authUser.getUserId(), boardId));
         return ResponseEntity.ok().body(new IdResponse(postId));
     }
 
@@ -38,21 +38,20 @@ public class PostApiController {
     @Operation(summary = "게시글 조회", description = "특정 게시판의 게시글 전체 조회 API")
     public ResponseEntity<PageResponse<Post>> findAllPost(@PageableDefault(page = 0, size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
                                                           @PathVariable("boardId") long boardId) {
-        PageResponse<Post> posts = PageResponse.from(postService.findAll(pageable));
+        PageResponse<Post> posts = PageResponse.from(postService.findAll(pageable, boardId));
         return ResponseEntity.ok().body(posts);
     }
 
     @GetMapping("/boards/{boardId}/posts/{postId}")
     @Operation(summary = "게시글 조회", description = "게시글 단건 조회 API")
-    public ResponseEntity<PostResponse> findPost(@PathVariable("boardId") long boardId, @PathVariable("postId") long postId) {
+    public ResponseEntity<PostResponse> findPost(@PathVariable("postId") long postId) {
         Post post = postService.findById(postId);
         return ResponseEntity.ok().body(PostResponse.from(post));
     }
 
     @DeleteMapping("/boards/{boardId}/posts/{postId}")
     @Operation(summary = "게시글 삭제", description = "게시글 삭제 API")
-    public ResponseEntity<Void> deletePost(@PathVariable("boardId") long boardId,
-                                           @PathVariable("postId") long postId,
+    public ResponseEntity<Void> deletePost(@PathVariable("postId") long postId,
                                            @UserInfo AuthUser authUser) {
         postService.delete(authUser.getUserId(), postId);
         return ResponseEntity.noContent().build();
@@ -60,8 +59,11 @@ public class PostApiController {
 
     @PutMapping("/boards/{boardId}/posts/{postId}")
     @Operation(summary = "게시글 수정", description = "게시글 수정 API")
-    public ResponseEntity<IdResponse> updateBoard(@PathVariable("postId") long postId, @RequestBody UpsertPostRequest upsertPostRequest, @UserInfo AuthUser authUser) {
-        postService.update(upsertPostRequest.toUpsertPost(authUser.getUserId()), postId);
+    public ResponseEntity<IdResponse> updateBoard(@PathVariable("postId") long postId,
+                                                  @PathVariable("boardId") long boardId,
+                                                  @RequestBody UpsertPostRequest upsertPostRequest,
+                                                  @UserInfo AuthUser authUser) {
+        postService.update(upsertPostRequest.toUpsertPost(authUser.getUserId(), boardId), postId);
         return ResponseEntity.ok().body(new IdResponse(postId));
     }
 }

--- a/src/main/java/com/jootcamp/superboard/post/dto/UpsertPostRequest.java
+++ b/src/main/java/com/jootcamp/superboard/post/dto/UpsertPostRequest.java
@@ -12,11 +12,12 @@ public class UpsertPostRequest {
     private String title;
     private String content;
 
-    public UpsertPost toUpsertPost(long userId) {
+    public UpsertPost toUpsertPost(long userId, long boardId) {
         return UpsertPost.builder()
                 .title(title)
                 .content(content)
                 .userId(userId)
+                .boardId(boardId)
                 .build();
     }
 }

--- a/src/main/java/com/jootcamp/superboard/post/repository/entity/PostEntity.java
+++ b/src/main/java/com/jootcamp/superboard/post/repository/entity/PostEntity.java
@@ -22,12 +22,15 @@ public class PostEntity extends BaseWithDeletedEntity {
 
     private String content;
 
+    private long boardId;
+
     @Builder
-    public PostEntity(String title, String content, long userId){
+    public PostEntity(String title, String content, long userId, long boardId){
         this.title = title;
         this.content = content;
         this.setCreatedBy(userId);
         this.setDeleted(false);
+        this.boardId = boardId;
     }
 
     public void delete(long userId) {
@@ -35,10 +38,11 @@ public class PostEntity extends BaseWithDeletedEntity {
         this.setDeleted(true);
     }
 
-    public void update(String title, String content, long userId) {
+    public void update(String title, String content, long userId, long boardId) {
         this.title = title;
         this.content = content;
         this.setModifiedBy(userId);
+        this.boardId = boardId;
     }
 
 }

--- a/src/main/java/com/jootcamp/superboard/post/service/PostService.java
+++ b/src/main/java/com/jootcamp/superboard/post/service/PostService.java
@@ -25,7 +25,7 @@ public class PostService {
         return post.getId();
     }
 
-    public PageDto<Post> findAll(Pageable pageable) {
+    public PageDto<Post> findAll(Pageable pageable, long boardId) {
         Page<PostEntity> posts = postRepository.findAllByIsDeletedIsFalse(pageable);
 
         List<Post> postList = posts.getContent().stream().map(Post::from).toList();
@@ -55,6 +55,6 @@ public class PostService {
         PostEntity post = postRepository.findByIdAndIsDeletedIsFalse(postId)
                 .orElseThrow(()->new PostNotFoundException(postId));
 
-        post.update(upsertPost.getTitle(), upsertPost.getContent(), upsertPost.getUserId());
+        post.update(upsertPost.getTitle(), upsertPost.getContent(), upsertPost.getUserId(), upsertPost.getBoardId());
     }
 }

--- a/src/main/java/com/jootcamp/superboard/post/service/dto/Post.java
+++ b/src/main/java/com/jootcamp/superboard/post/service/dto/Post.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 public class Post {
     private String title;
     private String content;
+    private long boardId;
     private Long id;
     private Long userId;
     private LocalDateTime time;
@@ -23,6 +24,7 @@ public class Post {
         return Post.builder()
                 .title(post.getTitle())
                 .content(post.getContent())
+                .boardId(post.getBoardId())
                 .id(post.getId())
                 .userId(post.getCreatedBy())
                 .time(post.getModifiedAt())

--- a/src/main/java/com/jootcamp/superboard/post/service/dto/UpsertPost.java
+++ b/src/main/java/com/jootcamp/superboard/post/service/dto/UpsertPost.java
@@ -14,12 +14,14 @@ public class UpsertPost {
     private String title;
     private String content;
     private Long userId;
+    private long boardId;
 
     public PostEntity toEntity() {
         return PostEntity.builder()
                 .title(title)
                 .content(content)
                 .userId(userId)
+                .boardId(boardId)
                 .build();
     }
 }

--- a/src/test/java/com/jootcamp/superboard/post/controller/PostApiControllerTest.java
+++ b/src/test/java/com/jootcamp/superboard/post/controller/PostApiControllerTest.java
@@ -42,7 +42,7 @@ class PostApiControllerTest {
     protected ObjectMapper objectMapper;
 
     @BeforeEach
-    public void BoardSetUp() {
+    public void setUpBoard() {
         boardRepository.deleteAll();
 
         BoardEntity board = BoardEntity.builder()

--- a/src/test/java/com/jootcamp/superboard/post/controller/PostApiControllerTest.java
+++ b/src/test/java/com/jootcamp/superboard/post/controller/PostApiControllerTest.java
@@ -1,17 +1,27 @@
 package com.jootcamp.superboard.post.controller;
 
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jootcamp.superboard.board.controller.dto.BoardResponse;
+import com.jootcamp.superboard.board.controller.dto.UpsertBoardRequest;
+import com.jootcamp.superboard.board.repository.BoardRepository;
+import com.jootcamp.superboard.board.repository.entity.BoardEntity;
 import com.jootcamp.superboard.post.repository.PostRepository;
 import com.jootcamp.superboard.post.service.dto.UpsertPost;
+import com.jootcamp.superboard.user.controller.dto.AuthUser;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -23,16 +33,36 @@ class PostApiControllerTest {
     PostRepository repository;
 
     @Autowired
+    BoardRepository boardRepository;
+
+    @Autowired
     protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @BeforeEach
+    public void BoardSetUp() {
+        boardRepository.deleteAll();
+
+        BoardEntity board = BoardEntity.builder()
+                .title("유머게시판")
+                .description("웃긴 게시글만 모음")
+                .userId(2024L)
+                .build();
+        boardRepository.save(board);
+    }
 
     @Test
     void findAllPost() throws Exception{
-        //Given
-        final String url = "/posts";
+
+        // Given
+        final Long boardId = 1L;  // 이 부분에 실제 boardId를 넣어줍니다.
+        final String url = String.format("/boards/%d/posts", boardId);
         String title = "게시글";
         String content = "게시글이다";
 
-        final UpsertPost saveData = new UpsertPost(title, content, 2024L);
+        final UpsertPost saveData = new UpsertPost(title, content, 2024L, 1L);
 
         repository.save(saveData.toEntity());
 


### PR DESCRIPTION
1. PostEntity에 BoardId 필드 추가
    - 생성자와 `update()` 파라미터로 추가

2. PostService에서 BoardId 필드 받는 코드 추가
    - `findAll()` 파라미터로 추가
    - `update()`의 정보 수정하는 부분에 파라미터 추가

3. PostController에서 BoardId 필드 받는 코드 추가
      - `@PathVariable("boardId") long boardId` 삭제
	      - `findPost`
	      - `deletePost`

      - `@PathVariable("boardId") long boardId` 추가
        - `updateBoard`

4. 관련 Dto들 수정
    - UpsertPostRequest
    - UpsertPost
    - Post

5. post test 코드 수정

close #92 