### PR TITLE
#fix - issue 96 : options 필터제외

### DIFF
--- a/src/main/java/com/jootcamp/superboard/common/filter/LoginCheckFilter.java
+++ b/src/main/java/com/jootcamp/superboard/common/filter/LoginCheckFilter.java
@@ -4,6 +4,7 @@ import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
+import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -41,6 +42,8 @@ public class LoginCheckFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String path = request.getRequestURI();
+
+        if(request.getMethod().equals(HttpMethod.OPTIONS.name())) return true; 
 
         if (path.startsWith("/board") || path.startsWith("/post")) {
             return request.getMethod().equals("GET");


### PR DESCRIPTION
`shouldNotFilter()` 메서드에 
-  `if(request.getMethod().equals(HttpMethod.OPTIONS.name()))` 추가

close #96